### PR TITLE
Use Assignment Expression (Walrus) In Conditional

### DIFF
--- a/rembg/_version.py
+++ b/rembg/_version.py
@@ -169,8 +169,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     """Get version information from git keywords."""
     if "refnames" not in keywords:
         raise NotThisMethod("Short version file found")
-    date = keywords.get("date")
-    if date is not None:
+    if (date := keywords.get("date")) is not None:
         # Use only the last line.  Previous lines may contain GPG signature
         # information.
         date = date.splitlines()[-1]
@@ -290,7 +289,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
         raise NotThisMethod("'git rev-parse --abbrev-ref' returned error")
     branch_name = branch_name.strip()
 
-    if branch_name == "HEAD":
+    if (branch_name := branch_name.strip()) == "HEAD":
         # If we aren't exactly on a branch, pick a branch which represents
         # the current commit. If all else fails, we are on a branchless
         # commit.

--- a/rembg/commands/p_command.py
+++ b/rembg/commands/p_command.py
@@ -146,8 +146,7 @@ def p_command(
 
     def process(each_input: pathlib.Path) -> None:
         try:
-            mimetype = filetype.guess(each_input)
-            if mimetype is None:
+            if (mimetype := filetype.guess(each_input)) is None:
                 return
             if mimetype.mime.find("image") < 0:
                 return

--- a/rembg/sessions/u2net_custom.py
+++ b/rembg/sessions/u2net_custom.py
@@ -34,8 +34,7 @@ class U2netCustomSession(BaseSession):
         Raises:
             ValueError: If model_path is None.
         """
-        model_path = kwargs.get("model_path")
-        if model_path is None:
+        if (model_path := kwargs.get("model_path")) is None:
             raise ValueError("model_path is required")
 
         super().__init__(model_name, sess_opts, providers, *args, **kwargs)
@@ -84,8 +83,7 @@ class U2netCustomSession(BaseSession):
         Returns:
             str: The absolute path to the model files.
         """
-        model_path = kwargs.get("model_path")
-        if model_path is None:
+        if (model_path := kwargs.get("model_path")) is None:
             return
 
         return os.path.abspath(os.path.expanduser(model_path))

--- a/versioneer.py
+++ b/versioneer.py
@@ -1103,8 +1103,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     """Get version information from git keywords."""
     if "refnames" not in keywords:
         raise NotThisMethod("Short version file found")
-    date = keywords.get("date")
-    if date is not None:
+    if (date := keywords.get("date")) is not None:
         # Use only the last line.  Previous lines may contain GPG signature
         # information.
         date = date.splitlines()[-1]
@@ -1224,7 +1223,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
         raise NotThisMethod("'git rev-parse --abbrev-ref' returned error")
     branch_name = branch_name.strip()
 
-    if branch_name == "HEAD":
+    if (branch_name := branch_name.strip()) == "HEAD":
         # If we aren't exactly on a branch, pick a branch which represents
         # the current commit. If all else fails, we are on a branchless
         # commit.
@@ -1726,8 +1725,7 @@ def get_versions(verbose=False):
     except NotThisMethod:
         pass
 
-    from_vcs_f = handlers.get("pieces_from_vcs")
-    if from_vcs_f:
+    if from_vcs_f := handlers.get("pieces_from_vcs"):
         try:
             pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
             ver = render(pieces, cfg.style)


### PR DESCRIPTION
This codemod updates places where two separate statements involving an assignment and conditional can be replaced with a single Assignment Expression (commonly known as the walrus operator).

Many developers use this operator in new code that they write but don't have the time to find and update every place in existing code. So we do it for you! We believe this leads to more concise and readable code.

The changes from this codemod look like this:

```diff
- x = foo()
- if x is not None:
+ if (x := foo()) is not None:
      print(x)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/use-walrus-if](https://docs.pixee.ai/codemods/python/pixee_python_use-walrus-if)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Cpixeeai%2Frembg%7C9feed9d08fd91d56077847395e379e503280961e)

<!--{"type":"DRIP","codemod":"pixee:python/use-walrus-if"}-->